### PR TITLE
[DOM-62801] - Add list permissions for sagemaker resources

### DIFF
--- a/role_policies.tf
+++ b/role_policies.tf
@@ -104,8 +104,8 @@ data "aws_iam_policy_document" "role_permissions_policy" {
       "sagemaker:InvokeEndpoint",
       "sagemaker:InvokeEndpointWithResponseStream",
       "sagemaker:ListEndpointConfigs",
-      "sagemaker:ListModels",
       "sagemaker:ListEndpoints",
+      "sagemaker:ListModels",
       "sagemaker:UpdateEndpoint",
       "sagemaker:UpdateEndpointWeightsAndCapacities"
     ]

--- a/role_policies.tf
+++ b/role_policies.tf
@@ -105,6 +105,7 @@ data "aws_iam_policy_document" "role_permissions_policy" {
       "sagemaker:InvokeEndpointWithResponseStream",
       "sagemaker:ListEndpointConfigs",
       "sagemaker:ListModels",
+      "sagemaker:ListEndpoints",
       "sagemaker:UpdateEndpoint",
       "sagemaker:UpdateEndpointWeightsAndCapacities"
     ]

--- a/role_policies.tf
+++ b/role_policies.tf
@@ -103,6 +103,8 @@ data "aws_iam_policy_document" "role_permissions_policy" {
       "sagemaker:DescribeModel",
       "sagemaker:InvokeEndpoint",
       "sagemaker:InvokeEndpointWithResponseStream",
+      "sagemaker:ListEndpointConfigs",
+      "sagemaker:ListModels",
       "sagemaker:UpdateEndpoint",
       "sagemaker:UpdateEndpointWeightsAndCapacities"
     ]


### PR DESCRIPTION
After this PR, https://github.com/cerebrotech/pham-juno-operator-service/pull/161, our cleanup process for sagemaker resources will require listing the resources (because we want to match on all names which contain the prefix rather than knowing the exact name we want to delete) 